### PR TITLE
Ensure directory exists before creating README

### DIFF
--- a/ansible/roles/atmo-user-deployment-scripts/defaults/main.yml
+++ b/ansible/roles/atmo-user-deployment-scripts/defaults/main.yml
@@ -6,6 +6,7 @@ POST_SCRIPT_DIR: "{{ SCRIPTS_ROOT }}/post-scripts.d"
 POST_SCRIPT_LOG_DIR: /var/log/atmo/post-scripts
 
 POST_MAKE_DIRS:
+  - "{{ SCRIPTS_ROOT }}"
   - "{{ POST_SCRIPT_DIR }}"
   - "{{ INSTANCE_SCRIPT_AVAILABLE_DIR }}"
   - "{{ INSTANCE_SCRIPT_DIR }}"

--- a/ansible/roles/atmo-user-deployment-scripts/tasks/main.yml
+++ b/ansible/roles/atmo-user-deployment-scripts/tasks/main.yml
@@ -4,14 +4,15 @@
 - fail: msg="Variable ASYNC_SCRIPTS is not set."
   when: ASYNC_SCRIPTS is not defined
 
-- name: deploy_script_0 - make a README for context
+- name: deploy_script_0 - make directories for scripts and logs
+  file: path={{ item }} state=directory
+  with_items: '{{ POST_MAKE_DIRS }}'
+
+- name: deploy_script_1 - make a README for context
   template:
     src: README.txt.j2
     dest: "{{SCRIPTS_ROOT}}/README.txt"
 
-- name: deploy_script_1 - make directories for post scripts and logs
-  file: path={{ item }} state=directory
-  with_items: '{{ POST_MAKE_DIRS }}'
 
 - name: deploy_script_2a - copy scripts to available scripts directory
   copy:


### PR DESCRIPTION
Problem: Ansible fails to create README.txt when /etc/atmo doesn't exist
Solution: Create /etc/atmo first

I ran into this issue when I deployed against
https://local.atmo.cloud/application/images/680